### PR TITLE
Possibly prevent the package from being python-version specific

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://github.com/askerdb/pyCSCS
 
 build:
-  noarch: generic
+  noarch: python
   
 requirements:
   host:


### PR DESCRIPTION
As per https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#source-section